### PR TITLE
Fix compatiblity with G++ 4.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8)
 PROJECT(j4-dmenu)
 
 INCLUDE_DIRECTORIES(include)
-SET(CMAKE_CXX_FLAGS "-std=c++0x -Wall -pedantic -Wextra -O2")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -Wall -pedantic -Wextra -O2")
 
 ADD_EXECUTABLE(
     j4-dmenu-desktop

--- a/src/dmenu.hh
+++ b/src/dmenu.hh
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <iostream>
 #include <unistd.h>
+#include <stdexcept>
 
 #include <sys/stat.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Hi,

I had some problems to build your project on a Debian Wheezy with G++ 4.7.
Here is the patch that solved my build issues.

The option `-std=c++0x` refers to the experimental support of the C++11 draft.
But C++11 isn't a draft anymore, and the correct option is now `-std=c++11`.

By the way, the exception `std::runtime_error` is defined in the header `stdexcept`, it needs to be included.

Cordially,
David Delassus.
