### PR TITLE
Implements GenericName search.

### DIFF
--- a/src/Applications.hh
+++ b/src/Applications.hh
@@ -28,6 +28,12 @@ public:
                 app = current_app.second;
                 match_length = name.length();
             }
+
+            const std::string &generic_name = current_app.second->generic_name;
+            if(generic_name.size() > match_length && startswith(choice, generic_name)) {
+                app = current_app.second;
+                match_length = generic_name.length();
+            }
         }
 
         if(!match_length) {

--- a/src/LocaleSuffixes.hh
+++ b/src/LocaleSuffixes.hh
@@ -73,7 +73,7 @@ private:
         for(auto &suffix : suffixset) {
             this->suffixes[i++] = strdup(suffix.c_str());
 #ifdef DEBUG
-            printf("LocaleSuffix: %s\n", this->suffixes[i-1]);
+            fprintf(stderr, "LocaleSuffix: %s\n", this->suffixes[i-1]);
 #endif
         }
         this->suffixes[i++] = 0;

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -49,6 +49,9 @@ public:
         // Transfer the list to dmenu
         for(auto &app : apps) {
             this->dmenu->write(app.second->name);
+            const std::string &generic_name = app.second->generic_name;
+            if(generic_name.size() && app.second->name != generic_name)
+                this->dmenu->write(generic_name);
         }
 
         this->dmenu->display();

--- a/src/SearchPath.hh
+++ b/src/SearchPath.hh
@@ -57,7 +57,7 @@ private:
         for(auto path : sp) {
             this->search_path.push_back(replace(path, "//", "/"));
 #ifdef DEBUG
-            printf("SearchPath: %s\n", this->search_path.back().c_str());
+            fprintf(stderr, "SearchPath: %s\n", this->search_path.back().c_str());
 #endif
         }
     }

--- a/src/TestApplication.cc
+++ b/src/TestApplication.cc
@@ -58,6 +58,7 @@ TEST_CASE("Application/valid/gimp", "Tests correct parsing of localization and s
 
     REQUIRE( app.read(path.c_str(), &buffer, &size) );
     REQUIRE( app.name == "Bildmanipulilo (GIMP = GNU Image Manipulation Program)" );
+    REQUIRE( app.generic_name == "Bildredaktilo" );
     REQUIRE( app.exec == "gimp-2.8 %U" );
     REQUIRE( !app.terminal );
 
@@ -104,7 +105,7 @@ TEST_CASE("Application/flag/hidden=true", "Test for an issue where the name wasn
     size_t size = 4096;
     std::string path(test_files + "applications/hidden.desktop");
 
-    REQUIRE( !app.read(path.c_str(), &buffer, &size) );
+    REQUIRE(!app.read(path.c_str(), &buffer, &size) );
     REQUIRE( app.name == "hiddenApp" );
     REQUIRE( app.exec == "hiddenApp" );
 
@@ -122,6 +123,7 @@ TEST_CASE("Application/spaces_after_equals", "Test whether spaces after the equa
     REQUIRE( app.read(path.c_str(), &buffer, &size) );
     //It should be "Htop", not "     Htop"
     REQUIRE( app.name == "Htop" );
+    REQUIRE( app.generic_name == "Process Viewer" );
 
     free(buffer);
 }
@@ -140,6 +142,7 @@ TEST_CASE("Application/onlyShowIn", "Test whether the OnlyShowIn tag works")
     Application app(ls, &env);
     REQUIRE( app.read(path.c_str(), &buffer, &size));
     REQUIRE( app.name == "Htop" );
+    REQUIRE( app.generic_name == "Process Viewer" );
 
     //Case 2: The app should not be shown in this environment
     env.clear();
@@ -147,6 +150,7 @@ TEST_CASE("Application/onlyShowIn", "Test whether the OnlyShowIn tag works")
     Application app2(ls, &env);
     REQUIRE(!app2.read(path.c_str(), &buffer, &size));
     REQUIRE( app2.name == "Htop");
+    REQUIRE( app2.generic_name == "Process Viewer" );
 
     free(buffer);
 }
@@ -163,8 +167,9 @@ TEST_CASE("Application/notShowIn", "Test whether the NotShowIn tag works")
     env.emplace_back("i3");
     env.emplace_back("Gnome");
     Application app(ls, &env);
-    REQUIRE(! app.read(path.c_str(), &buffer, &size));
+    REQUIRE(!app.read(path.c_str(), &buffer, &size));
     REQUIRE( app.name == "Htop" );
+    REQUIRE( app.generic_name == "Process Viewer" );
 
     //Case 2: The app should be shown in this environment
     env.clear();
@@ -172,6 +177,7 @@ TEST_CASE("Application/notShowIn", "Test whether the NotShowIn tag works")
     Application app2(ls, &env);
     REQUIRE( app2.read(path.c_str(), &buffer, &size));
     REQUIRE( app2.name == "Htop");
+    REQUIRE( app2.generic_name == "Process Viewer" );
 
     free(buffer);
 }

--- a/test_files/applications/whitespaces.desktop
+++ b/test_files/applications/whitespaces.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=     Htop
+GenericName=  Process Viewer
 Type=Application
 Comment=Show System Processes
 Terminal=true


### PR DESCRIPTION
This PR adds a `generic_name` field in `Application` and the corresponding parsing. It also introduces `parse_localestring` that takes care of choosing the best match (by length) for localized strings. Some tests are added to cover the new `generic_name` field.

Also, some DEBUG `printf` are replaced with `fprintf(stderr` so it is more coherent with the other DEBUG prints.

This PR fixes #31.