### PR TITLE
Allow the user to exclude generic desktop entry names

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Options:
         Enables reading $XDG_CURRENT_DESKTOP to determine the desktop environment
     --display-binary
         Display binary name after each entry (off by default)
+    --no-generic
+        Do not include the generic name of desktop entries
     --term=<command>
         Sets the terminal emulator used to start terminal apps
     --usage-log=<file>

--- a/j4-dmenu-desktop.1
+++ b/j4-dmenu-desktop.1
@@ -18,6 +18,8 @@ Executed with your shell ($SHELL) or \fI\,/bin/sh\/\fP
 Enables reading $XDG_CURRENT_DESKTOP to determine the desktop environment
 .IP \fB\-\-display\-binary\fR
 Display binary name after each entry (off by default)
+.IP \fB\-\-no\-generic\fR
+Do not include the generic name of desktop entries
 .IP \fB\-\-term=\fR<command>
 Sets the terminal emulator used to start terminal apps
 .IP \fB\-\-usage\-log=\fR<file>

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -77,7 +77,7 @@ public:
         for(auto &app : iteration_order) {
             this->dmenu->write(app.second->name);
             const std::string &generic_name = app.second->generic_name;
-            if(!generic_name.empty() && app.second->name != generic_name)
+            if(!exclude_generic && !generic_name.empty() && app.second->name != generic_name)
                 this->dmenu->write(generic_name);
         }
 
@@ -115,6 +115,8 @@ private:
                 "\tEnables reading $XDG_CURRENT_DESKTOP to determine the desktop environment\n"
                 "    --display-binary\n"
                 "\tDisplay binary name after each entry (off by default)\n"
+                "    --no-generic\n"
+                "\tDo not include the generic name of desktop entries\n"
                 "    --term=<command>\n"
                 "\tSets the terminal emulator used to start terminal apps\n"
                 "    --usage-log=<file>\n"
@@ -136,6 +138,7 @@ private:
                 {"term",    required_argument,  0,  't'},
                 {"help",    no_argument,        0,  'h'},
                 {"display-binary", no_argument, 0,  'b'},
+                {"no-generic", no_argument,     0,  'n'},
                 {"usage-log", required_argument,0,  'l'},
                 {0,         0,                  0,  0}
             };
@@ -160,6 +163,8 @@ private:
             case 'b':
                 formatter = format_type::with_binary_name;
                 break;
+            case 'n':
+                exclude_generic = true;
             case 'l':
                 usage_log = optarg;
                 break;
@@ -251,6 +256,7 @@ private:
 
     stringlist_t environment;
     bool use_xdg_de = false;
+    bool exclude_generic = false;
 
     Dmenu *dmenu = 0;
     SearchPath search_path;


### PR DESCRIPTION
Added a new option, `--no-generic`, which excludes generic names from the output of j4-dmenu-desktop.
As an example, j4-dmenu-desktop will no longer display "Web Browser" for Chrome and Firefox.