### PR TITLE
Correcting version of Catch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(NOT DEFINED NO_TESTS)
     catch
     PREFIX ${CMAKE_BINARY_DIR}/catch
     GIT_TAG Catch1.x
-    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_REPOSITORY https://github.com/catchorg/Catch2
     TIMEOUT 10
     UPDATE_COMMAND git pull
     CONFIGURE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,8 @@ if(NOT DEFINED NO_TESTS)
   ExternalProject_Add(
     catch
     PREFIX ${CMAKE_BINARY_DIR}/catch
-    GIT_REPOSITORY https://github.com/philsquared/Catch.git
+    GIT_TAG Catch1.x
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     TIMEOUT 10
     UPDATE_COMMAND git pull
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
[Catch](//github.com/philsquared/Catch) moved to [Catch2](//github.com/catchorg/Catch2).
Thanks to @Zetten from the issue #71.