### PR TITLE
Add option to disable downloading Catch during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
   set(CXX_OPT "-std=c++11")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_OPT} ${CXX_OPT} -Wall -pedantic -Wextra -O2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_OPT} -Wall -Wextra -pedantic -O2")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
 if(NOT DEFINED NO_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.8)
 
 project(j4-dmenu)
 
+option(WITH_TESTS "Build and run tests" ON)
+option(WITH_GIT_CATCH "Use a Git checkout of Catch to build the tests" ON)
+
 if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7")
   set(CXX_OPT "-std=c++0x")
 else()
@@ -11,53 +14,54 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_OPT} -Wall -Wextra -pedantic -O2")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
-if(NOT DEFINED NO_TESTS)
-  include(ExternalProject)
-
-  ExternalProject_Add(
-    catch
-    PREFIX ${CMAKE_BINARY_DIR}/catch
-    GIT_TAG Catch1.x
-    GIT_REPOSITORY https://github.com/catchorg/Catch2
-    TIMEOUT 10
-    UPDATE_COMMAND git pull
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-    LOG_DOWNLOAD ON
-    )
-
-  # Expose required variable (CATCH_INCLUDE_DIR) to parent scope
-  ExternalProject_Get_Property(catch source_dir)
-  set(CATCH_INCLUDE_DIR ${source_dir}/include CACHE INTERNAL "Path to include folder for Catch")
-
-  # Includes Catch in the project:
-  #add_subdirectory(${EXT_PROJECTS_DIR}/catch)
-  include_directories(${CATCH_INCLUDE_DIR} ${COMMON_INCLUDES})
-
+if(WITH_TESTS)
+  enable_testing(true)
+  add_test(
+          NAME j4-dmenu-tests
+          COMMAND j4-dmenu-tests
+  )
+  add_executable(
+          j4-dmenu-tests
+          src/Test.cc
+          src/TestApplication.cc
+          src/TestApplicationRunner.cc
+          src/TestSearchPath.cc
+          src/TestLocaleSuffixes.cc
+          src/TestFileFinder.cc
+          src/TestFormatters.cc
+  )
   add_definitions(-DTEST_FILES="${CMAKE_CURRENT_SOURCE_DIR}/test_files/")
 
-  enable_testing(true)
-
-  add_test(
-    NAME j4-dmenu-tests
-    COMMAND j4-dmenu-tests
+  if(WITH_GIT_CATCH)
+    include(ExternalProject)
+    ExternalProject_Add(
+      catch
+      PREFIX ${CMAKE_BINARY_DIR}/catch
+      GIT_TAG Catch1.x
+      GIT_REPOSITORY https://github.com/catchorg/Catch2
+      TIMEOUT 10
+      UPDATE_COMMAND git pull
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ""
+      INSTALL_COMMAND ""
+      LOG_DOWNLOAD ON
     )
+    add_dependencies(j4-dmenu-tests catch)
 
-  add_executable(
-    j4-dmenu-tests
-    src/Test.cc
-    src/TestApplication.cc
-    src/TestApplicationRunner.cc
-    src/TestSearchPath.cc
-    src/TestLocaleSuffixes.cc
-    src/TestFileFinder.cc
-    src/TestFormatters.cc
-    )
+    # Expose required variable (CATCH_INCLUDE_DIR) to parent scope
+    ExternalProject_Get_Property(catch source_dir)
+    set(CATCH_INCLUDE_DIR ${source_dir}/include CACHE INTERNAL "Path to include folder for Catch")
+  else()
+    # Use system-installed version of Catch
+    find_path(CATCH_INCLUDE_DIR catch.hpp PATH_SUFFIXES catch)
+    if(NOT CATCH_INCLUDE_DIR)
+      message(FATAL_ERROR "Catch include directory not found")
+    endif()
+  endif(WITH_GIT_CATCH)
 
-  add_dependencies(j4-dmenu-tests catch)
-endif(NOT DEFINED NO_TESTS)
-
+  # Include Catch in the project
+  include_directories(${CATCH_INCLUDE_DIR} ${COMMON_INCLUDES})
+endif(WITH_TESTS)
 
 add_executable(
     j4-dmenu-desktop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,21 +2,9 @@ cmake_minimum_required(VERSION 2.8)
 
 project(j4-dmenu)
 
-exec_program(
-  ${CMAKE_CXX_COMPILER}
-  ARGS --version
-  OUTPUT_VARIABLE _compiler_output
-  )
-string(REGEX REPLACE "(\n.*$)" "" cxx_compiler_version "${_compiler_output}")
-string(REGEX REPLACE "([^0-9.])|([0-9.][^0-9.])" "" cxx_compiler_version "${cxx_compiler_version}")
-
-if(CMAKE_COMPILER_IS_GNUCXX)
-  if(${cxx_compiler_version} VERSION_LESS "4.7.0")
-    set(CXX_OPT "-std=c++0x")
-  else()
-    set(CXX_OPT "-std=c++11")
-  endif()
-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7")
+  set(CXX_OPT "-std=c++0x")
+else()
   set(CXX_OPT "-std=c++11")
 endif()
 


### PR DESCRIPTION
This PR makes a few improvements to CMakeLists.txt. The main change is a new option for disabling the automatic download of Catch during the build, and building the tests with the system-installed version of Catch instead.

The reason for this change is that I'm submitting j4-dmenu-desktop to the main Gentoo repository (gentoo/gentoo#6933), but I've had to unconditionally disable tests because network access during the build is not allowed.