### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@ Building is the usual cmake/make thingy:
 
 ### Archlinux
 
-The package is provided by the AUR. You can install it with an AUR helper of your choice: `j4-dmenu-desktop-git` or manually by invoking the following commands as a regular user. (to build packages from the AUR, the `base-devel` package group is assumed to be installed)
+The package is provided by the AUR. You can install it with an AUR helper of your choice: `j4-dmenu-desktop-git` or `j4-dmenu-desktop`. Else, you may install it manually by invoking the following commands as a regular user. (to build packages from the AUR, the `base-devel` package group is assumed to be installed)
 
     git clone https://aur.archlinux.org/j4-dmenu-desktop.git    
     cd j4-dmenu-desktop
+    makepkg -si
+
+or for the latest:
+
+    git clone https://aur.archlinux.org/j4-dmenu-desktop-git.git
+    cd j4-dmenu-desktop-git
     makepkg -si
 
 ### FreeBSD

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ Building is the usual cmake/make thingy:
 
 The package is provided by the AUR. You can install it with an AUR helper of your choice: `j4-dmenu-desktop-git` or manually by invoking the following commands as a regular user. (to build packages from the AUR, the `base-devel` package group is assumed to be installed)
 
-    wget https://aur.archlinux.org/cgit/aur.git/snapshot/j4-dmenu-desktop-git.tar.gz
-    tar xf j4-dmenu-desktop-git.tar.gz
-    cd j4-dmenu-desktop-git
+    git clone https://aur.archlinux.org/j4-dmenu-desktop.git    
+    cd j4-dmenu-desktop
     makepkg -si
-    
+
 ### FreeBSD
 
 j4-dmenu-desktop is now available in the FreeBSD Ports Collection. A prebuilt package can be installed via


### PR DESCRIPTION
The cleaner method of installing from an AUR repo is to `git clone` it, since it allows for an update mechanism via `git pull`s. Also, it allows access to previous versions of the build script if the user desires that.

I'm also including both the AUR packages that serve it.