### PR TITLE
Re-add support for %k

### DIFF
--- a/src/Application.hh
+++ b/src/Application.hh
@@ -59,6 +59,9 @@ public:
     // Path
     std::string path;
 
+    // Path of .desktop file
+    std::string location;
+
     // Terminal app
     bool terminal = false;
 

--- a/src/ApplicationRunner.hh
+++ b/src/ApplicationRunner.hh
@@ -116,7 +116,7 @@ private:
         // The localized name of the application
         replace(exec, "%c", "\"" + quote(this->app.name) + "\"");
 
-        replace(exec, "%k", "");
+        replace(exec, "%k", this->app.location);
         replace(exec, "%i", "");
 
         replace(exec, "%%", "%");

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -192,7 +192,7 @@ private:
             chdir(path.c_str());
             FileFinder finder("./", ".desktop");
             while(finder++) {
-                handle_file(*finder);
+                handle_file(*finder, path);
             }
         }
 
@@ -201,10 +201,11 @@ private:
         chdir(original_wd);
     }
 
-    void handle_file(const std::string &file) {
+    void handle_file(const std::string &file, const std::string &base_path) {
         Application *dft = new Application(suffixes, use_xdg_de ? &environment : 0);
         bool file_read = dft->read(file.c_str(), &buf, &bufsz);
         dft->name = this->appformatter(*dft);
+        dft->location = base_path + file;
 
         if(file_read && !dft->name.empty()) {
             if(apps.count(dft->id)) {


### PR DESCRIPTION
See #88 for motivation.

The structure of `main.cc` has changed since 579ee11a361fc58bfa43d426fd45a6a7f88be6a7, so the base path wasn't readily available anymore. This seemed like the best solution.