### PR TITLE
Added a --wrapper option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,8 @@ Options:
         Display binary name after each entry (off by default)
     --no-generic
         Do not include the generic name of desktop entries
-    --prefix=<prefix>
-		Provide a prefix for the command to run.
-		Useful in case you want 'i3 exec'
+	--wrapper=<wrapper>
+		A wrapper binary. Useful in case you want to wrap into 'i3 exec'
     --term=<command>
         Sets the terminal emulator used to start terminal apps
     --usage-log=<file>

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Options:
         Display binary name after each entry (off by default)
     --no-generic
         Do not include the generic name of desktop entries
+    --prefix=<prefix>
+		Provide a prefix for the command to run.
+		Useful in case you want 'i3 exec'
     --term=<command>
         Sets the terminal emulator used to start terminal apps
     --usage-log=<file>

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -242,8 +242,9 @@ private:
         }
 
         this->dmenu->display();
-
-        std::string command = this->wrapper+" \""+get_command()+"\"";
+        std::string command = get_command();
+        if (this->wrapper.length())
+            command = this->wrapper+" \""+get_command()+"\"";
         delete this->dmenu;
 
         if(!command.empty()) {

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -244,7 +244,7 @@ private:
         this->dmenu->display();
         std::string command = get_command();
         if (this->wrapper.length())
-            command = this->wrapper+" \""+get_command()+"\"";
+            command = this->wrapper+" \""+command+"\"";
         delete this->dmenu;
 
         if(!command.empty()) {

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -108,6 +108,8 @@ private:
                 "    --usage-log=<file>\n"
                 "\tMust point to a read-writeable file (will create if not exists).\n"
                 "\tIn this mode entries are sorted by usage frequency.\n"
+				"    --wrapper=<wrapper>\n"
+				"\tA wrapper binary. Useful in case you want to wrap into 'i3 exec'\n"
                 "    --wait-on=<path>\n"
                 "\tMust point to a path where a file can be created.\n"
                 "\tIn this mode no menu will be shown. Instead the program waits for <path>\n"
@@ -133,7 +135,7 @@ private:
                 {"no-generic", no_argument,     0,  'n'},
                 {"usage-log", required_argument,0,  'l'},
                 {"wait-on", required_argument,  0,  'w'},
-                {"prefix", required_argument,   0,  'p'},
+                {"wrapper", required_argument,   0,  'W'},
                 {0,         0,                  0,  0}
             };
 
@@ -166,8 +168,8 @@ private:
             case 'w':
                 wait_on = optarg;
                 break;
-			case 'p':
-				this->prefix = optarg;
+			case 'W':
+				this->wrapper = optarg;
 				break;
             default:
                 exit(1);
@@ -241,7 +243,7 @@ private:
 
         this->dmenu->display();
 
-        std::string command = this->prefix+" "+get_command();
+        std::string command = this->wrapper+" \""+get_command()+"\"";
         delete this->dmenu;
 
         if(!command.empty()) {
@@ -322,7 +324,7 @@ private:
 private:
     std::string dmenu_command;
     std::string terminal;
-	std::string prefix;
+	std::string wrapper;
     const char *wait_on = 0;
 
     stringlist_t environment;

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -133,6 +133,7 @@ private:
                 {"no-generic", no_argument,     0,  'n'},
                 {"usage-log", required_argument,0,  'l'},
                 {"wait-on", required_argument,  0,  'w'},
+                {"prefix", required_argument,   0,  'p'},
                 {0,         0,                  0,  0}
             };
 
@@ -165,6 +166,9 @@ private:
             case 'w':
                 wait_on = optarg;
                 break;
+			case 'p':
+				this->prefix = optarg;
+				break;
             default:
                 exit(1);
             }
@@ -237,7 +241,7 @@ private:
 
         this->dmenu->display();
 
-        std::string command = get_command();
+        std::string command = this->prefix+" "+get_command();
         delete this->dmenu;
 
         if(!command.empty()) {
@@ -318,6 +322,7 @@ private:
 private:
     std::string dmenu_command;
     std::string terminal;
+	std::string prefix;
     const char *wait_on = 0;
 
     stringlist_t environment;


### PR DESCRIPTION
Can execute the commands with a certain wrapper.
Helps if you want something like
`i3 exec $MY_COMMAND` and $MY_COMMAND binary is available.
Fixes problems like [these](https://www.reddit.com/r/i3wm/comments/3bmhnm/open_programs_in_the_workspace_they_were_called/)

Usage: (in i3 context)
j4-dmenu-desktop --wrapper "i3 exec"