### PR TITLE
Add nix/nixos to distribution packages list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ j4-dmenu-desktop is in Debian stable:
 
     sudo apt install j4-dmenu-desktop
 
+### Nix / NixOS
+
+j4-dmenu-desktop is in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/j4-dmenu-desktop/default.nix):
+
+    nix-env --install j4-dmenu-desktop
+    # Or use pkgs attribute of the same name in NixOS configuration 
+
+
 ## Invocation
 
 Usage:


### PR DESCRIPTION
It seems j4-dmenu-desktop has been in nixpkgs [for some time](https://github.com/NixOS/nixpkgs/commits/master/pkgs/applications/misc/j4-dmenu-desktop/default.nix). It would be good to add this information to the README.