### PR TITLE
Add --no-exec option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Options:
         to be written to (use echo > path). Every time this happens a menu will be shown.
         Desktop files are parsed ahead of time.
         Perfoming 'echo -n q > path' will exit the program.
+    --no-exec
+        Do not execute selected command, send to stdout instead
     --help
         Display this help message
 

--- a/j4-dmenu-desktop.1
+++ b/j4-dmenu-desktop.1
@@ -31,6 +31,8 @@ In this mode no menu will be shown. Instead the program waits for <path>
 to be written to (use echo > path). Every time this happens a menu will be shown.
 Desktop files are parsed ahead of time.
 Perfoming 'echo -n q > path' will exit the program.
+.IP \fB\-\-no\-exec\fR
+Do not execute selected command, send to stdout instead
 .IP \fB\-\-help\fR
 Display this help message
 

--- a/src/ApplicationRunner.hh
+++ b/src/ApplicationRunner.hh
@@ -39,8 +39,6 @@ public:
         const std::string &name = this->app.name;
         std::stringstream command;
 
-        puts(exec.c_str());
-
         if(this->app.terminal) {
             // Execute in terminal
 

--- a/src/Applications.hh
+++ b/src/Applications.hh
@@ -36,21 +36,13 @@ public:
             }
         }
 
-        if(!match_length) {
-            // No matching app found, just execute the input in a shell
-            const char *shell = 0;
-            if((shell = getenv("SHELL")) == 0)
-                shell = "/bin/sh";
-
-            fprintf(stderr, "%s -i -c '%s'\n", shell, choice.c_str());
-
-            // -i -c was tested with both bash and zsh.
-            exit(execl(shell, shell, "-i", "-c",  choice.c_str(), 0, nullptr));
+        if(match_length) {
+            // +1 b/c there must be whitespace we add back later...
+            args = choice.substr(match_length, choice.length()-1);
+        } else {
+            // No matching app found, args contains user dmenu choice
+            args = choice;
         }
-
-        // +1 b/c there must be whitespace we add back later...
-        args = choice.substr(match_length, choice.length()-1);
-        //args = choice;
 
         return std::make_pair(app, args);
     }

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -114,6 +114,8 @@ private:
                 "\tto be written to (use echo > path). Every time this happens a menu will be shown.\n"
                 "\tDesktop files are parsed ahead of time.\n"
                 "\tPerfoming 'echo -n q > path' will exit the program.\n"
+                "    --no-exec\n"
+                "\tDo not execute selected command, send to stdout instead\n"
                 "    --help\n"
                 "\tDisplay this help message\n"
                );
@@ -133,6 +135,7 @@ private:
                 {"no-generic", no_argument,     0,  'n'},
                 {"usage-log", required_argument,0,  'l'},
                 {"wait-on", required_argument,  0,  'w'},
+                {"no-exec", no_argument,        0,  'e'},
                 {0,         0,                  0,  0}
             };
 
@@ -164,6 +167,9 @@ private:
                 break;
             case 'w':
                 wait_on = optarg;
+                break;
+            case 'e':
+                no_exec = true;
                 break;
             default:
                 exit(1);
@@ -247,7 +253,7 @@ private:
         std::string command = get_command();
         delete this->dmenu;
 
-        if(!command.empty()) {
+        if(!no_exec && !command.empty()) {
             static const char *shell = 0;
             if((shell = getenv("SHELL")) == 0)
                 shell = "/bin/sh";
@@ -300,7 +306,7 @@ private:
         std::string args;
         Application *app;
 
-        printf("Read %d .desktop files, found %lu apps.\n", parsed_files, apps.size());
+        fprintf(stderr, "Read %d .desktop files, found %lu apps.\n", parsed_files, apps.size());
 
         choice = dmenu->read_choice(); // Blocks
         if(choice.empty())
@@ -332,6 +338,7 @@ private:
     stringlist_t environment;
     bool use_xdg_de = false;
     bool exclude_generic = false;
+    bool no_exec = false;
 
     Dmenu *dmenu = 0;
     SearchPath search_path;

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -253,7 +253,11 @@ private:
         std::string command = get_command();
         delete this->dmenu;
 
-        if(!no_exec && !command.empty()) {
+        if(!command.empty()) {
+            if (no_exec) {
+                printf("%s\n", command.c_str());
+                return 0;
+            }
             static const char *shell = 0;
             if((shell = getenv("SHELL")) == 0)
                 shell = "/bin/sh";
@@ -315,6 +319,9 @@ private:
         fprintf(stderr, "User input is: %s %s\n", choice.c_str(), args.c_str());
 
         std::tie(app, args) = apps.search(choice);
+        if (!app) {
+            return args;
+        }
 
         if(usage_log) {
             apps.update_log(usage_log, app);


### PR DESCRIPTION
This PR adds a `--no-exec` option that prevents `j4-dmenu-desktop` from executing the selected command. Instead, the command is printed to stdout. This could, for example, be passed to `i3 exec` or `swaymsg exec` via `xargs`.

May be an alternate approach to PR #94 