### PR TITLE
Replace `echo -ne` with printf

### DIFF
--- a/src/ApplicationRunner.hh
+++ b/src/ApplicationRunner.hh
@@ -36,7 +36,6 @@ public:
 
     const std::string command() {
         std::string exec = this->application_command();
-        const std::string &name = this->app.name;
         std::stringstream command;
 
         puts(exec.c_str());
@@ -58,9 +57,13 @@ public:
                 return std::string();
             }
 
+            // name with ' escaped for use in single-quoted shell string
+            std::string nameesc(this->app.name);
+            replace(nameesc, "'", "'\\''");
+
             fprintf(script, "#!/bin/sh\n");
             fprintf(script, "rm %s\n", scriptname);
-            fprintf(script, "echo -ne \"\\033]2;%s\\007\"\n", name.c_str());
+            fprintf(script, "printf '\\033]2;%%s\\007' '%s'\n", nameesc.c_str());
             fprintf(script, "exec %s", exec.c_str());
 
             //closes also fd


### PR DESCRIPTION
Launching a terminal application on Debian results in `-ne` appearing at the top of the terminal above any command output.  This is due to [echo as defined in POSIX] not supporting `-e` (and use of escape sequences and -n being non-portable) and [dash], the default shell in Debian, including -ne in its output, which then appears on the first line of launched terminal applications.

This PR fixes the issue by using [printf] instead of `echo -ne`.

Note: The previous implementation unescaped any `printf(3)` escape sequences in `Name`, rather than only the specified [Desktop Entry string escape sequences].  The new behavior matches the current behavior for `Exec`, where no escape sequences are unescaped.  If unescaping is desired, it could be added here or in `Application::read`.

Thanks for considering,
Kevin

[dash]: https://salsa.debian.org/debian/dash
[echo as defined in POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html
[Desktop Entry string escape sequences]: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#value-types
[printf]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html