### PR TITLE
Added --run-command option, obsoletes --wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Options:
         Do not include the generic name of desktop entries
 	--wrapper=<wrapper>
 		A wrapper binary. Useful in case you want to wrap into 'i3 exec'
+	--run-command=<cmd>
+		The command to run instead of the selected binary. You can embed the
+		selected binary name using `{}` keyword
     --term=<command>
         Sets the terminal emulator used to start terminal apps
     --usage-log=<file>

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -266,7 +266,8 @@ private:
 
 		// --run-command switch
 		if (this->run_command.length()){
-			command = replace(this->run_command, this->run_command_token, command);
+			command = replace(command, "'", "'\"'\"'");
+			command = replace(this->run_command, this->run_command_token, "'" + command + "'");
 		}
 
         delete this->dmenu;

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -108,6 +108,9 @@ private:
                 "\tIn this mode entries are sorted by usage frequency.\n"
 				"    --wrapper=<wrapper>\n"
 				"\tA wrapper binary. Useful in case you want to wrap into 'i3 exec'\n"
+				"    --run-command=<cmd>\n"
+				"\tThe command to run instead of the selected binary. You can embed the"
+				" selected binary name using `{}` keyword"
                 "    --wait-on=<path>\n"
                 "\tMust point to a path where a file can be created.\n"
                 "\tIn this mode no menu will be shown. Instead the program waits for <path>\n"
@@ -137,6 +140,7 @@ private:
                 {"wait-on", required_argument,  0,  'w'},
                 {"no-exec", no_argument,        0,  'e'},
                 {"wrapper", required_argument,   0,  'W'},
+                {"run-command", required_argument,   0,  'r'},
                 {0,         0,                  0,  0}
             };
 
@@ -175,6 +179,9 @@ private:
             case 'W':
                 this->wrapper = optarg;
                 break;
+			case 'r':
+				this->run_command = optarg;
+				break;
             default:
                 exit(1);
             }
@@ -256,6 +263,12 @@ private:
         std::string command = get_command();
         if (this->wrapper.length())
             command = this->wrapper+" \""+command+"\"";
+
+		// --run-command switch
+		if (this->run_command.length()){
+			command = replace(this->run_command, this->run_command_token, command);
+		}
+
         delete this->dmenu;
 
         if(!command.empty()) {
@@ -346,6 +359,9 @@ private:
     std::string dmenu_command;
     std::string terminal;
 	std::string wrapper;
+	std::string run_command;
+
+	const std::string run_command_token = "{}";
     const char *wait_on = 0;
 
     stringlist_t environment;
@@ -369,4 +385,3 @@ private:
 
     const char *usage_log = 0;
 };
-


### PR DESCRIPTION
Wrapper was an idea exclusively useful for running the binary via `i3-exec`.     
While that is of utmost importance, the current --run-command feature subsets wrapper and a *lot more*.
    
The current syntax is
 ```
            --run-command "/usr/bin/anybinary {}"
 ```
    
The --wrapper *could* be replaced with a similar structure
 ```
            --run-command "wrapper_binary '{}'"`
 ```   
I strongly advocate for `--run-command` and obsolete `--wrapper` as it is way more awesome and flexible. The idea was directly inspired by rofi's `-run-command`
