### PR TITLE
bump required minimum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(j4-dmenu)
 


### PR DESCRIPTION
This avoids a warning by recentish cmake versions.