### PR TITLE
Add --term-args command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ j4-dmenu-desktop is in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pk
 
 Usage:
 
-    j4-dmenu-desktop [--dmenu="dmenu -i"] [--term="i3-sensible-terminal"]
+    j4-dmenu-desktop [--dmenu="dmenu -i"] [--term="i3-sensible-terminal"] [--term-args="-e"]
     j4-dmenu-desktop --help
 
 Options:
@@ -99,10 +99,12 @@ Options:
         Display binary name after each entry (off by default)
     --no-generic
         Do not include the generic name of desktop entries
-	--wrapper=<wrapper>
-		A wrapper binary. Useful in case you want to wrap into 'i3 exec'
+    --wrapper=<wrapper>
+        A wrapper binary. Useful in case you want to wrap into 'i3 exec'
     --term=<command>
         Sets the terminal emulator used to start terminal apps
+    --term-args=<args>
+        Sets the terminal emulator arguments ('-e' by default)
     --usage-log=<file>
         Must point to a read-writeable file (will create if not exists).
         In this mode entries are sorted by usage frequency.
@@ -111,7 +113,7 @@ Options:
         In this mode no menu will be shown. Instead the program waits for <path>
         to be written to (use echo > path). Every time this happens a menu will be shown.
         Desktop files are parsed ahead of time.
-        Perfoming 'echo -n q > path' will exit the program.
+        Performing 'echo -n q > path' will exit the program.
     --no-exec
         Do not execute selected command, send to stdout instead
     --help

--- a/src/ApplicationRunner.hh
+++ b/src/ApplicationRunner.hh
@@ -30,8 +30,8 @@
 class ApplicationRunner
 {
 public:
-    ApplicationRunner(const std::string &terminal_emulator, const Application &app, const std::string &args)
-        : app(app), args(args), terminal_emulator(terminal_emulator) {
+    ApplicationRunner(const std::string &terminal_emulator, const std::string &terminal_args, const Application &app, const std::string &args)
+        : app(app), args(args), terminal_emulator(terminal_emulator), terminal_args(terminal_args) {
     }
 
     const std::string command() {
@@ -74,8 +74,8 @@ public:
             //As mkstemp sets the file permissions to 0600, we need to set it to 0700 to execute the script
             chmod(scriptname, S_IRWXU);
 
-            command << this->terminal_emulator;
-            command << " -e \"" << scriptname << "\"";
+            command << this->terminal_emulator << " " << this->terminal_args << " ";
+            command << "\"" << scriptname << "\"";
         } else {
             command << exec;
         };
@@ -130,6 +130,7 @@ private:
     std::string args;
 
     const std::string &terminal_emulator;
+    const std::string &terminal_args;
 };
 
 #endif

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -28,7 +28,7 @@ class Main
 {
 public:
     Main()
-        : dmenu_command("dmenu -i"), terminal("i3-sensible-terminal") {
+        : dmenu_command("dmenu -i"), terminal("i3-sensible-terminal"), terminal_args("-e") {
 
     }
 
@@ -95,7 +95,7 @@ private:
                 "A faster replacement for i3-dmenu-desktop\n"
                 "Copyright (c) 2013 Marian Beermann, GPLv3 license\n"
                 "\nUsage:\n"
-                "\tj4-dmenu-desktop [--dmenu=\"dmenu -i\"] [--term=\"i3-sensible-terminal\"]\n"
+                "\tj4-dmenu-desktop [--dmenu=\"dmenu -i\"] [--term=\"i3-sensible-terminal\"] [--term-args=\"-e\"]\n"
                 "\tj4-dmenu-desktop --help\n"
                 "\nOptions:\n"
                 "    --dmenu=<command>\n"
@@ -109,11 +109,13 @@ private:
                 "\tDo not include the generic name of desktop entries\n"
                 "    --term=<command>\n"
                 "\tSets the terminal emulator used to start terminal apps\n"
+                "    --term-args=<arguments>\n"
+                "\tSets the terminal emulator arguments ('-e' by default)\n"
                 "    --usage-log=<file>\n"
                 "\tMust point to a read-writeable file (will create if not exists).\n"
                 "\tIn this mode entries are sorted by usage frequency.\n"
-				"    --wrapper=<wrapper>\n"
-				"\tA wrapper binary. Useful in case you want to wrap into 'i3 exec'\n"
+                "    --wrapper=<wrapper>\n"
+                "\tA wrapper binary. Useful in case you want to wrap into 'i3 exec'\n"
                 "    --wait-on=<path>\n"
                 "\tMust point to a path where a file can be created.\n"
                 "\tIn this mode no menu will be shown. Instead the program waits for <path>\n"
@@ -133,17 +135,18 @@ private:
         while (true) {
             int option_index = 0;
             static struct option long_options[] = {
-                {"dmenu",   required_argument,  0,  'd'},
-                {"use-xdg-de",   no_argument,   0,  'x'},
-                {"term",    required_argument,  0,  't'},
-                {"help",    no_argument,        0,  'h'},
-                {"display-binary", no_argument, 0,  'b'},
-                {"no-generic", no_argument,     0,  'n'},
-                {"usage-log", required_argument,0,  'l'},
-                {"wait-on", required_argument,  0,  'w'},
-                {"no-exec", no_argument,        0,  'e'},
-                {"wrapper", required_argument,   0,  'W'},
-                {0,         0,                  0,  0}
+                {"dmenu",          required_argument, 0,  'd'},
+                {"use-xdg-de",     no_argument,       0,  'x'},
+                {"term",           required_argument, 0,  't'},
+                {"term-args",      required_argument, 0,  'g'},
+                {"help",           no_argument,       0,  'h'},
+                {"display-binary", no_argument,       0,  'b'},
+                {"no-generic",     no_argument,       0,  'n'},
+                {"usage-log",      required_argument, 0,  'l'},
+                {"wait-on",        required_argument, 0,  'w'},
+                {"no-exec",        no_argument,       0,  'e'},
+                {"wrapper",        required_argument, 0,  'W'},
+                {0,                0,                 0,  0}
             };
 
             int c = getopt_long(argc, argv, "d:t:xhb", long_options, &option_index);
@@ -159,6 +162,9 @@ private:
                 break;
             case 't':
                 this->terminal = optarg;
+                break;
+            case 'g':
+                this->terminal_args = optarg;
                 break;
             case 'h':
                 this->print_usage(stderr);
@@ -344,13 +350,14 @@ private:
             }
         }
 
-        ApplicationRunner app_runner(terminal, *app, args);
+        ApplicationRunner app_runner(terminal, terminal_args, *app, args);
         return app_runner.command();
     }
 
 private:
     std::string dmenu_command;
     std::string terminal;
+    std::string terminal_args;
 	std::string wrapper;
     const char *wait_on = 0;
 

--- a/src/TestApplicationRunner.cc
+++ b/src/TestApplicationRunner.cc
@@ -13,6 +13,6 @@ TEST_CASE("ApplicationRunner/escape", "Regression test for issue #18, %c was not
     app.name = "Regression Test 18";
     app.exec = "1234 --caption %c";
 
-    ApplicationRunner runner("", app, "");
+    ApplicationRunner runner("", "", app, "");
     REQUIRE( runner.command() == "1234 --caption \"Regression Test 18\"" );
 }


### PR DESCRIPTION
Some terminal emulators (like foot) do not support an argument `-e`. With `--term-args` it is possible to customize the arguments passed to the terminal emulator. If this option is not provided `-e` is used by default to maintain backwards compatibility.

In case of foot we would use it like this:
```
--term="foot" --term-args=""
```