### PR TITLE
Change test in TestSearchPath.cc when /usr/share/applications/ does not exist

### DIFF
--- a/src/TestSearchPath.cc
+++ b/src/TestSearchPath.cc
@@ -15,8 +15,13 @@ TEST_CASE("SearchPath/XDG_DATA_HOME", "Check SearchPath honors XDG_DATA_HOME")
     SearchPath sp;
     std::vector<std::string> result(sp.begin(), sp.end());
 
-    REQUIRE( result.size() == 1 );
-    REQUIRE( result[0] == "/usr/share/applications/" );
+    struct stat dirdata;
+    if (stat("/usr/share/applications", &dirdata) == 0 && S_ISDIR(dirdata.st_mode)) { // test if /usr/share/applications is valid
+        REQUIRE( result.size() == 1 );
+        REQUIRE( result.front() == "/usr/share/applications/" );
+    } else {
+        REQUIRE( result.size() == 0 );
+    }
 }
 
 TEST_CASE("SearchPath/XDG_DATA_DIRS", "Check SearchPath honors XDG_DATA_DIRS")


### PR DESCRIPTION
The current version of `TestSearchPath.hh` assumes that the folder `/usr/share/applications` exists. The test fails if it does not exist, even when `SearchPath` is behaving correctly. This PR changes the test when `/usr/share/applications` does not exist.