### PR TITLE
With --no-generic, do not look for generic names when selecting app

### DIFF
--- a/src/Applications.hh
+++ b/src/Applications.hh
@@ -15,7 +15,7 @@ public:
         }
     }
 
-    std::pair<Application *, std::string> search(const std::string &choice) {
+    std::pair<Application *, std::string> search(const std::string &choice, bool exclude_generic) {
         Application *app = 0;
         std::string args;
         size_t match_length = 0;
@@ -28,11 +28,12 @@ public:
                 app = current_app.second;
                 match_length = name.length();
             }
-
-            const std::string &generic_name = current_app.second->generic_name;
-            if(generic_name.size() > match_length && startswith(choice, generic_name)) {
-                app = current_app.second;
-                match_length = generic_name.length();
+            if (!exclude_generic) {
+                const std::string &generic_name = current_app.second->generic_name;
+                if(generic_name.size() > match_length && startswith(choice, generic_name)) {
+                    app = current_app.second;
+                    match_length = generic_name.length();
+                }
             }
         }
 

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -330,7 +330,7 @@ private:
 
         fprintf(stderr, "User input is: %s %s\n", choice.c_str(), args.c_str());
 
-        std::tie(app, args) = apps.search(choice);
+        std::tie(app, args) = apps.search(choice, exclude_generic);
         if (!app) {
             return args;
         }
@@ -376,4 +376,3 @@ private:
 
     const char *usage_log = 0;
 };
-


### PR DESCRIPTION
While `--no-generic` was excluding generic names from display, they
were still looked up when getting back the application to execute from
dmenu. Also exclude them in this case.