### PR TITLE
Add case insensitive sorting of applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Options:
         to be written to (use echo > path). Every time this happens a menu will be shown.
         Desktop files are parsed ahead of time.
         Perfoming 'echo -n q > path' will exit the program.
+    --case-insensitive
+        Sort applications case insensitively
     --no-exec
         Do not execute selected command, send to stdout instead
     --help

--- a/j4-dmenu-desktop.1
+++ b/j4-dmenu-desktop.1
@@ -36,7 +36,7 @@ Must point to a path where a file can be created. In this mode no menu will be s
 to be written to (use echo > path). Every time this happens a menu will be shown. Desktop files are parsed ahead of time. Performing 'echo -n q > path' will exit the program.
 .It Fl Fl wrapper Ar wrapper
 A wrapper binary. Useful in case you want to wrap into 'i3 exec'.
-.It Fl c , Fl Fl case-insensitive
+.It Fl i , Fl Fl case-insensitive
 Sort applications case insensitively
 .It Fl h , Fl Fl help
 Display help message.

--- a/j4-dmenu-desktop.1
+++ b/j4-dmenu-desktop.1
@@ -36,6 +36,8 @@ Must point to a path where a file can be created. In this mode no menu will be s
 to be written to (use echo > path). Every time this happens a menu will be shown. Desktop files are parsed ahead of time. Performing 'echo -n q > path' will exit the program.
 .It Fl Fl wrapper Ar wrapper
 A wrapper binary. Useful in case you want to wrap into 'i3 exec'.
+.It Fl c , Fl Fl case-insensitive
+Sort applications case insensitively
 .It Fl h , Fl Fl help
 Display help message.
 .El

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -67,10 +67,14 @@ public:
             iteration_order.emplace_back(app.first, app.second);
         }
 
-        std::sort(iteration_order.begin(), iteration_order.end(), [](
+        std::sort(iteration_order.begin(), iteration_order.end(), [this](
             const std::pair<std::string, const Application *> &s1,
             const std::pair<std::string, const Application *> &s2) {
-                return s1.second->name < s2.second->name;
+                if(case_insensitive) {
+                      return string_case_cmp(s1.second->name, s2.second->name);
+                } else {
+                      return s1.second->name < s2.second->name;
+                }
         });
 
         if(usage_log) {
@@ -123,6 +127,8 @@ private:
                 "\t\tPerfoming 'echo -n q > path' will exit the program.\n"
                 "\t--wrapper=<wrapper>\n"
                 "\t\tA wrapper binary. Useful in case you want to wrap into 'i3 exec'\n"
+                "\t-c, --case-insensitive\n"
+                "\t\tSort the applications case insensitively\n"
                 "\t-h, --help\n"
                 "\t\tDisplay this help message\n"
                );
@@ -144,10 +150,11 @@ private:
                 {"wait-on", required_argument,  0,  'w'},
                 {"no-exec", no_argument,        0,  'e'},
                 {"wrapper", required_argument,   0,  'W'},
+                {"case-insensitive", no_argument,   0,  'c'},
                 {0,         0,                  0,  0}
             };
 
-            int c = getopt_long(argc, argv, "d:t:xhb", long_options, &option_index);
+            int c = getopt_long(argc, argv, "d:t:xhbc", long_options, &option_index);
             if(c == -1)
                 break;
 
@@ -181,6 +188,9 @@ private:
                 break;
             case 'W':
                 this->wrapper = optarg;
+                break;
+            case 'c':
+                case_insensitive = true;
                 break;
             default:
                 exit(1);
@@ -359,6 +369,7 @@ private:
     bool use_xdg_de = false;
     bool exclude_generic = false;
     bool no_exec = false;
+    bool case_insensitive = false;
 
     Dmenu *dmenu = 0;
     SearchPath search_path;

--- a/src/Main.hh
+++ b/src/Main.hh
@@ -127,7 +127,7 @@ private:
                 "\t\tPerfoming 'echo -n q > path' will exit the program.\n"
                 "\t--wrapper=<wrapper>\n"
                 "\t\tA wrapper binary. Useful in case you want to wrap into 'i3 exec'\n"
-                "\t-c, --case-insensitive\n"
+                "\t-i, --case-insensitive\n"
                 "\t\tSort the applications case insensitively\n"
                 "\t-h, --help\n"
                 "\t\tDisplay this help message\n"
@@ -150,11 +150,11 @@ private:
                 {"wait-on", required_argument,  0,  'w'},
                 {"no-exec", no_argument,        0,  'e'},
                 {"wrapper", required_argument,   0,  'W'},
-                {"case-insensitive", no_argument,   0,  'c'},
+                {"case-insensitive", no_argument,   0,  'i'},
                 {0,         0,                  0,  0}
             };
 
-            int c = getopt_long(argc, argv, "d:t:xhbc", long_options, &option_index);
+            int c = getopt_long(argc, argv, "d:t:xhbi", long_options, &option_index);
             if(c == -1)
                 break;
 
@@ -189,7 +189,7 @@ private:
             case 'W':
                 this->wrapper = optarg;
                 break;
-            case 'c':
+            case 'i':
                 case_insensitive = true;
                 break;
             default:

--- a/src/Utilities.hh
+++ b/src/Utilities.hh
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <string.h>
+#include <strings.h>
 
 
 typedef std::list<std::string> stringlist_t;

--- a/src/Utilities.hh
+++ b/src/Utilities.hh
@@ -109,6 +109,10 @@ inline std::string get_variable(const std::string &var)
         return "";
 }
 
+inline bool string_case_cmp(const std::string &str1, const std::string &str2){
+  return (0 > strncasecmp(str1.c_str(), str2.c_str(), std::min(str1.length(),str2.length())));
+}
+
 #define pfatale(msg) perror(msg); abort();
 
 


### PR DESCRIPTION
This patch adds the -c, --case-insensitive option, which makes the alphabetical sorting of the applications be done by a utility function that sorts them case insensitively.