### PR TITLE
Fix build with GCC 13

### DIFF
--- a/src/Application.hh
+++ b/src/Application.hh
@@ -19,7 +19,8 @@
 #define APPLICATION_DEF
 
 #include <algorithm>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 #include <unistd.h>
 
 #include "Utilities.hh"


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/895200