### PR TITLE
Make unit tests independent of the user's locale

### DIFF
--- a/src/LocaleSuffixes.hh
+++ b/src/LocaleSuffixes.hh
@@ -26,7 +26,11 @@
 class LocaleSuffixes
 {
 public:
-    LocaleSuffixes(std::string locale = set_locale());
+    LocaleSuffixes(std::string locale);
+
+    static LocaleSuffixes from_environment() {
+        return LocaleSuffixes(set_locale());
+    }
 
     // this function tests if a given string is matched by the current locale
     // it returns an int that signifies how well it matches so that Application

--- a/src/main.cc
+++ b/src/main.cc
@@ -1347,7 +1347,7 @@ int main(int argc, char **argv) {
         for (const std::string &file : item.files)
             SPDLOG_DEBUG("   {}", file);
     }
-    LocaleSuffixes locales;
+    LocaleSuffixes locales = LocaleSuffixes::from_environment();
     {
         auto suffixes = locales.list_suffixes_for_logging_only();
         SPDLOG_DEBUG("Found {} locale suffixes:", suffixes.size());

--- a/tests/TestAppManager.cc
+++ b/tests/TestAppManager.cc
@@ -110,7 +110,7 @@ TEST_CASE("Test basic functionality + hidden desktop file", "[AppManager]") {
               TEST_FILES "a/applications/firefox.desktop",
               TEST_FILES "a/applications/hidden.desktop"}}
     },
-        {}, LocaleSuffixes());
+        {}, LocaleSuffixes("en_US"));
 
     REQUIRE(apps.count() == 3);
 
@@ -142,7 +142,7 @@ TEST_CASE("Test basic NotShowIn/OnlyShowIn interactions", "[AppManager]") {
                  {TEST_FILES "applications/notShowIn.desktop",
                   TEST_FILES "applications/onlyShowIn.desktop"}}
         },
-            {"i3"}, LocaleSuffixes());
+            {"i3"}, LocaleSuffixes("en_US"));
 
         REQUIRE(apps.count() == 2);
         REQUIRE(apps.view_name_app_mapping().size() == 2);
@@ -155,7 +155,7 @@ TEST_CASE("Test basic NotShowIn/OnlyShowIn interactions", "[AppManager]") {
                  {TEST_FILES "applications/notShowIn.desktop",
                   TEST_FILES "applications/onlyShowIn.desktop"}}
         },
-            {"Kde"}, LocaleSuffixes());
+            {"Kde"}, LocaleSuffixes("en_US"));
 
         REQUIRE(apps.count() == 2);
         REQUIRE(apps.view_name_app_mapping().size() == 0);
@@ -168,7 +168,7 @@ TEST_CASE("Test basic NotShowIn/OnlyShowIn interactions", "[AppManager]") {
                  {TEST_FILES "applications/notShowIn.desktop",
                   TEST_FILES "applications/onlyShowIn.desktop"}}
         },
-            {"Gnome"}, LocaleSuffixes());
+            {"Gnome"}, LocaleSuffixes("en_US"));
 
         REQUIRE(apps.count() == 2);
         REQUIRE(apps.view_name_app_mapping().size() == 2);
@@ -184,7 +184,7 @@ TEST_CASE("Test ID collisions", "[AppManager]") {
                 {TEST_FILES "usr/local/share/applications/",
                  {TEST_FILES "usr/local/share/applications/collision.desktop"}},
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
         REQUIRE(apps.count() == 1);
         {
             ctype check{
@@ -203,7 +203,7 @@ TEST_CASE("Test ID collisions", "[AppManager]") {
                 {TEST_FILES "usr/share/applications/",
                  {TEST_FILES "usr/share/applications/collision.desktop"}      },
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
         REQUIRE(apps.count() == 1);
         {
             ctype check{
@@ -226,7 +226,7 @@ TEST_CASE("Test collisions and remove()", "[AppManager]") {
              {TEST_FILES "b/applications/chrome.desktop",
               TEST_FILES "b/applications/safari.desktop"} },
     },
-        {}, LocaleSuffixes());
+        {}, LocaleSuffixes("en_US"));
 
     REQUIRE(apps.count() == 4);
 
@@ -324,7 +324,7 @@ TEST_CASE("Test removing app with shadowed name", "[AppManager]") {
                 {TEST_FILES "applications/",
                  {TEST_FILES "applications/chromium-variant1.desktop"}},
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
 
         REQUIRE(apps.count() == 3);
 
@@ -361,7 +361,7 @@ TEST_CASE("Test removing app with shadowed name", "[AppManager]") {
                  {TEST_FILES "applications/chromium-variant1.desktop",
                   TEST_FILES "applications/chromium-variant2.desktop"}},
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
 
         REQUIRE(apps.count() == 2);
 
@@ -395,7 +395,7 @@ TEST_CASE("Test collisions, remove() and add()", "[AppManager]") {
             {TEST_FILES "c/applications/",
              {TEST_FILES "c/applications/vivaldi.desktop"}}
     },
-        {}, LocaleSuffixes());
+        {}, LocaleSuffixes("en_US"));
     // clang-format on
     REQUIRE(apps.count() == 4);
 
@@ -540,7 +540,7 @@ TEST_CASE("Test overwriting with add()", "[AppManager]") {
             {TEST_FILES "c/applications/",
              {TEST_FILES "c/applications/vivaldi.desktop"}     }
     },
-        {}, LocaleSuffixes());
+        {}, LocaleSuffixes("en_US"));
 
     apps.check_inner_state();
 
@@ -627,7 +627,7 @@ TEST_CASE("Test desktop ID collisions, remove() and add()", "[AppManager]") {
                 {TEST_FILES "usr/share/applications/",
                  {TEST_FILES "usr/share/applications/collision.desktop"}},
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
 
         REQUIRE(apps.count() == 1);
 
@@ -651,7 +651,7 @@ TEST_CASE("Test desktop ID collisions, remove() and add()", "[AppManager]") {
                 {TEST_FILES "usr/local/share/applications/",
                  {TEST_FILES "usr/local/share/applications/collision.desktop"}},
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
 
         REQUIRE(apps.count() == 1);
         {
@@ -683,7 +683,7 @@ TEST_CASE("Test adding a disabled file", "[AppManager]") {
              {TEST_FILES "a/applications/chromium.desktop",
               TEST_FILES "a/applications/firefox.desktop"}},
     },
-        {}, LocaleSuffixes());
+        {}, LocaleSuffixes("en_US"));
 
     REQUIRE(apps.count() == 2);
 
@@ -712,7 +712,7 @@ TEST_CASE("Test lookup by ID", "[AppManager]") {
               TEST_FILES "a/applications/firefox.desktop",
               TEST_FILES "a/applications/hidden.desktop"}}
     },
-        {}, LocaleSuffixes());
+        {}, LocaleSuffixes("en_US"));
 
     REQUIRE(apps.lookup_by_ID("chromium.desktop").value().get().name ==
             "Chromium");
@@ -728,7 +728,7 @@ TEST_CASE("Test NotShowIn/OnlyShowIn", "[AppManager]") {
                 {TEST_FILES "applications/",
                  {TEST_FILES "applications/notShowIn.desktop"}}
         },
-            {"Kde"}, LocaleSuffixes());
+            {"Kde"}, LocaleSuffixes("en_US"));
 
         REQUIRE(apps.count() == 3);
         {
@@ -766,7 +766,7 @@ TEST_CASE("Test NotShowIn/OnlyShowIn", "[AppManager]") {
                 {TEST_FILES "applications/",
                  {TEST_FILES "applications/notShowIn.desktop"}}
         },
-            {"i3"}, LocaleSuffixes());
+            {"i3"}, LocaleSuffixes("en_US"));
 
         REQUIRE(apps.count() == 3);
         {
@@ -811,7 +811,7 @@ TEST_CASE("Test add()ing mixed hidden and not hidden files (see #167)",
                   "usr/local/share/applications/couldbehidden.desktop"}},
                 {TEST_FILES "usr/share/applications/", {}}
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
         // clang-format on
 
         apps.check_inner_state();
@@ -847,7 +847,7 @@ TEST_CASE("Test add()ing mixed hidden and not hidden files (see #167)",
                  {TEST_FILES "usr/share/applications/couldbehidden.desktop"}},
                 {TEST_FILES "usr/local/share/applications/", {}}
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
         // clang-format on
 
         apps.check_inner_state();
@@ -908,7 +908,7 @@ TEST_CASE("Test reading a unreadable file.", "[AppManager]") {
              {TEST_FILES "applications/eagle.desktop"}           },
             {"/tmp/",                    {unreadable1.get_name()}}
     },
-        stringlist_t{}, LocaleSuffixes{}));
+        stringlist_t{}, LocaleSuffixes("en_US")));
 
     AppManager &apps = *container;
 
@@ -1011,7 +1011,7 @@ TEST_CASE("Test removing an unknown desktop file", "[AppManager]") {
               TEST_FILES "applications/gimp.desktop",
               TEST_FILES "applications/hidden.desktop"}}
     },
-        {}, LocaleSuffixes());
+        {}, LocaleSuffixes("en_US"));
 
     apps.check_inner_state();
 

--- a/tests/TestHistoryManager.cc
+++ b/tests/TestHistoryManager.cc
@@ -177,7 +177,7 @@ TEST_CASE("Test conversion from v0 to v1", "[History]") {
                      TEST_FILES "applications/visible.desktop",
                  }}
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
         HistoryManager hist =
             HistoryManager::convert_history_from_v0(tmpfile.get_name(), apps);
         REQUIRE(compare_maps(hist.view(), history));
@@ -225,7 +225,7 @@ TEST_CASE("Test imperfect conversion from history v0 to v1", "[History]") {
                      TEST_FILES "applications/visible.desktop",
                  }}
         },
-            {}, LocaleSuffixes());
+            {}, LocaleSuffixes("en_US"));
         HistoryManager hist =
             HistoryManager::convert_history_from_v0(tmpfile.get_name(), apps);
         REQUIRE(compare_maps(hist.view(), history));


### PR DESCRIPTION
A few tests load .desktop files which contain localized texts (namely gimp.desktop) and expect texts such as "Image Editor" in the output. However, those tests also use a default-constructed `LocaleSuffixes`, which uses the user's current locale.

Thus, those tests will fail when running on non-English locales, as the test will see the localized texts (e.g. "Bildeditor") instead.

Set a language explicitly when constructing `LocaleSuffixes` in tests to make them independent of the user's current locale. Plus, remove the default constructor and replace it with a more explicit static factory method instead.