### PR TITLE
Fix ordering of defaults for unset/empty XDG_DATA_DIRS

### DIFF
--- a/src/SearchPath.cc
+++ b/src/SearchPath.cc
@@ -42,7 +42,7 @@ stringlist_t get_search_path() {
 
     std::string xdg_data_dirs = get_variable("XDG_DATA_DIRS");
     if (xdg_data_dirs.empty())
-        xdg_data_dirs = "/usr/share/:/usr/local/share/";
+        xdg_data_dirs = "/usr/local/share/:/usr/share/";
 
     auto dirs = split(xdg_data_dirs, ':');
     for (auto &path : dirs) {

--- a/tests/TestSearchPath.cc
+++ b/tests/TestSearchPath.cc
@@ -42,15 +42,30 @@ TEST_CASE("Check SearchPath honors XDG_DATA_HOME", "[SearchPath]") {
     }
 }
 
+TEST_CASE("Check SearchPath defaults for unset XDG_DATA_DIRS", "[SearchPath]") {
+    setenv("XDG_DATA_HOME", "/does/not/exist", 1);
+    unsetenv("XDG_DATA_DIRS");
+
+    std::vector<std::string> result = get_search_path();
+
+    std::vector<std::string> expected;
+    if (is_directory("/usr/local/share/applications/"))
+        expected.push_back("/usr/local/share/applications/");
+    if (is_directory("/usr/share/applications/"))
+        expected.push_back("/usr/share/applications/");
+
+    REQUIRE(result == expected);
+}
+
 TEST_CASE("Check SearchPath honors XDG_DATA_DIRS", "[SearchPath]") {
     unsetenv("XDG_DATA_HOME");
     setenv("HOME", "/home/testuser", 1);
     setenv("XDG_DATA_DIRS",
-           TEST_FILES "usr/share/:" TEST_FILES "usr/local/share/", 1);
+           TEST_FILES "usr/local/share/:" TEST_FILES "usr/share/", 1);
 
     std::vector<std::string> result = get_search_path();
 
     REQUIRE(result.size() == 2);
-    REQUIRE(result[0] == TEST_FILES "usr/share/applications/");
-    REQUIRE(result[1] == TEST_FILES "usr/local/share/applications/");
+    REQUIRE(result[0] == TEST_FILES "usr/local/share/applications/");
+    REQUIRE(result[1] == TEST_FILES "usr/share/applications/");
 }


### PR DESCRIPTION
Administrator-owned .desktop files in /usr/local/share/applications/ should be able to override system files in /usr/share/applications/, if no XDG_DATA_DIRS is given. However, `get_search_paths` returned them in the opposite order, so that system .desktop files took precedence.

This is confirmed by the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/0.8/ar01s03.html):

> $XDG_DATA_DIRS defines the preference-ordered set of base directories
> If $XDG_DATA_DIRS is either not set or empty, a value equal to /usr/local/share/:/usr/share/ should be used.

Use the correct default so administrator-owned files take precedence.