### PR TITLE
Feature parity with Fuzzel, Wofi, (maybe) Rofi. Proper Quoting and Reserved Characters Handling in Arguments

### DIFF
--- a/src/CMDLineAssembler.cc
+++ b/src/CMDLineAssembler.cc
@@ -94,6 +94,9 @@ std::vector<std::string> convert_exec_to_command(std::string_view exec_key) {
                 case '"':
                     in_quotes = false;
                     break;
+		case '\'':
+		    in_quotes = false;
+		    break;
                 case '\\':
                     escaping = true;
                     break;
@@ -106,6 +109,9 @@ std::vector<std::string> convert_exec_to_command(std::string_view exec_key) {
                 case '"':
                     in_quotes = true;
                     break;
+		case '\'':
+		    in_quotes = true;
+		    break;
                 case ' ':
                     result.push_back(std::move(curr));
                     curr.clear();


### PR DESCRIPTION
Fuzzel, Wofi, and (maybe) Rofi quotes in the Exec line. This patch allows for j4-dmenu-desktop to launch the Exec line with quotes. It is rough around the edges but it's a good start.

An example entry:
Exec="/usr/bin/foobar" "--baz"

j4-dmenu-desktop doesn't consume the second argument in the Exec line causing issues when trying to launch desktop files like that. From what I am aware of these kinds of desktop files are rare.

Brief summary from [The Exec key](https://specifications.freedesktop.org/desktop-entry-spec/1.5/exec-variables.html)
Double quotes should enclose arguments, and certain characters like quotes, backticks, dollar signs, and backslashes must be escaped with a backslash. Implementations need to undo this quoting before expanding field codes and passing arguments to programs. Reserved characters include space, tab, newline, various punctuation marks, and symbols like tilde and ampersand. Got it!