### PR TITLE
Fix problems in manual page

### DIFF
--- a/j4-dmenu-desktop.1
+++ b/j4-dmenu-desktop.1
@@ -346,7 +346,7 @@ This is the same script used by
 The script will be generated only if this placeholder is specified at least once
 in
 .Fl Fl term .
-The script sets terminal title itself, it souldn't be necessary to set it
+The script sets terminal title itself, it shouldn't be necessary to set it
 manually.
 .Pp
 .Brq Ic cmdline@
@@ -434,7 +434,7 @@ Primary directory containing desktop files.
 .It Ev XDG_DATA_DIRS
 Additional directories containing desktop files.
 .It Ev XDG_CURRENT_DESKTOP
-Current desktop environment used for enabling/disabling desktop environemnt
+Current desktop environment used for enabling/disabling desktop environment
 dependent desktop files.
 Must be enabled by
 .Fl Fl use-xdg-de .
@@ -451,7 +451,9 @@ should generally work.
 .Lk https://github.com/enkore/j4-dmenu-desktop
 .Sh COPYRIGHT
 Copyright (C) 2013 enkore
-.Eo < Mt public+j4-dmenu-desktop@enkore.de Ec >
+.Eo <
+.Mt public+j4-dmenu-desktop@enkore.de
+.Ec >
 .Pp
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
@@ -466,4 +468,6 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program.
 If not, see
-.Eo < Lk http://www.gnu.org/licenses/ Ec > .
+.Eo <
+.Lk http://www.gnu.org/licenses/
+.Ec > .


### PR DESCRIPTION
While packaging j4-dmenu-desktop r3.1 for Debian, I noticed a few problems in the manul page. Here is the patch that fixes them:

- Fix two typos.
- Fix man error message: troff: error: automatically ending diversion 'doc-enclosure-box0' on exit
  caused by the invalid link in the end.
- Fix the appearance of the brackets around the email link.
