### PR TITLE
Fix misc spelling errors in comments and strings

### DIFF
--- a/etc/deprecated/_j4-dmenu-desktop
+++ b/etc/deprecated/_j4-dmenu-desktop
@@ -1,7 +1,7 @@
 #compdef j4-dmenu-desktop
 
 # Some of the flags accept executables. They are matced with _files -g \(\*\).
-# This is a glob that maches files that are executable.
+# This is a glob that matches files that are executable.
 
 # https://github.com/markfasheh/duperemove/blob/b76d569c4b96d4afb745b7970f87fbb0193b2792/completion/zsh/_duperemove
 # can serve as inspiration for further changes to ZSH completion. Duperemove is

--- a/j4-dmenu-desktop.1
+++ b/j4-dmenu-desktop.1
@@ -125,7 +125,7 @@ Set file log level.
 .It Fl Fl desktop-file-quirks Ar ARGS
 Modify
 .Nm j4-dmenu-desktop's
-desktop file parsing mechanism to accomodate desktop files not conforming to the
+desktop file parsing mechanism to accommodate desktop files not conforming to the
 Desktop Entry Specification.
 Several modes may be specified.
 They shall be separated by a comma (,).

--- a/src/CMDLineAssembler.cc
+++ b/src/CMDLineAssembler.cc
@@ -105,7 +105,7 @@ std::optional<std::string> validate_exec_key(std::string_view exec_key) {
         }
     }
     if (in_quotes)
-        return "\"\" qouted string is missing the end quote in the Exec field.";
+        return "\"\" quoted string is missing the end quote in the Exec field.";
     return {};
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1040,7 +1040,7 @@ do_wait_on(NotifyBase &notify, const char *wait_on, AppManager &appm,
             processes_to_wait_for = std::move(new_processes_to_wait_for);
         }
     }
-    // Make reaaly sure [[noreturn]] is upheld.
+    // Make really sure [[noreturn]] is upheld.
     abort();
 }
 

--- a/tests/ShellUnquote.cc
+++ b/tests/ShellUnquote.cc
@@ -98,7 +98,7 @@ std::string posix_shell_unqote(std::string_view str) {
     // <--
     // There could be a race condition between these lines of code. This is code
     // for unit tests, not for j4-dmenu-desktop, so I find this tolerable. The
-    // probability of hitting this race condition is miniscule. If input string
+    // probability of hitting this race condition is minuscule. If input string
     // is escaped well, no shell injection happened and the unit tests aren't
     // being run on a extremely slow computer, the race condition will never be
     // hit.

--- a/tests/system_tests/j4dd_run_helper.py
+++ b/tests/system_tests/j4dd_run_helper.py
@@ -47,7 +47,7 @@ def _assemble_error_message(
     Args:
         stdout: stdout contents
         stderr: stderr contents
-        override_env: overriden environment variables
+        override_env: overridden environment variables
         args: commandline executed
 
     Returns:
@@ -82,9 +82,9 @@ class _SubprocessRunResult:
 
 @dataclass
 class _AsyncData:
-    """A messanger class.
+    """A messenger class.
 
-    This is a messanger class between _run_j4dd_impl(),
+    This is a messenger class between _run_j4dd_impl(),
     _subprocess_asynchronous() run and AsyncJ4ddResult.
     _subprocess_asynchronous() needs this additional class to be able to return
     extra information without actually returning it from the function (because
@@ -267,7 +267,7 @@ def run_j4dd(
         # Execute first part of _run_j4dd_impl(), which executes
         # j4-dmenu-desktop but doesn't check the result of the execution.
         next(result)
-        # Immediatelly execute the rest of _run_j4dd_impl(), which may throw
+        # Immediately execute the rest of _run_j4dd_impl(), which may throw
         # J4ddRunError to signify that j4-dmenu-desktop exited with unexpected
         # exit status.
         next(result, None)


### PR DESCRIPTION
No functional changes.

This is on latest `develop` branch and can be fast-forwarded = merged without the need to have extra merge commits.