### PR TITLE
Allow compiling without notify support

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -16,7 +16,7 @@ option(
 option(
     'notify-implementation',
     type: 'combo',
-    choices: ['inotify', 'kqueue', 'auto'],
+    choices: ['inotify', 'kqueue', 'auto', 'none'],
     value: 'auto',
     description: 'Set the notify implementation.',
 )

--- a/src/main.cc
+++ b/src/main.cc
@@ -75,7 +75,7 @@
 
 #ifdef USE_KQUEUE
 #include "NotifyKqueue.hh"
-#else
+#elif defined USE_INOTIFY
 #include "NotifyInotify.hh"
 #endif
 
@@ -200,11 +200,13 @@ static void print_usage(FILE *f) {
         "    -h, --help\n"
         "        Display this help message\n\n"
         "See the manpage for a more detailed description of the flags.\n"
-        "j4-dmenu-desktop is compiled with "
+        "j4-dmenu-desktop is compiled "
 #ifdef USE_KQUEUE
-        "kqueue"
+        "with kqueue"
+#elif defined USE_INOTIFY
+        "with inotify"
 #else
-        "inotify"
+        "without notify"
 #endif
         " support.\n"
 #ifdef DEBUG
@@ -1554,12 +1556,18 @@ int main(int argc, char **argv) {
         if (wait_on) {
 #ifdef USE_KQUEUE
             NotifyKqueue notify(search_path);
-#else
+#elif defined USE_INOTIFY
             NotifyInotify notify(search_path);
 #endif
+#if defined USE_KQUEUE || defined USE_INOTIFY
             do_wait_on(notify, wait_on, appm, search_path,
                        command_retrieval_loop, executor.get());
             abort();
+#else
+            SPDLOG_ERROR(
+                "j4-dmenu-desktop is compiled without notify support.");
+            exit(EXIT_FAILURE);
+#endif
         } else {
             std::optional<RunPhase::CommandRetrievalLoop::CommandInfoVariant>
                 command = command_retrieval_loop.prompt_user_for_choice();

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,17 +6,17 @@ comp = meson.get_compiler('cpp')
 if get_option('notify-implementation') == 'auto'
   if host_machine.system() in ['freebsd', 'dragonfly', 'netbsd', 'openbsd']
     if comp.check_header('sys/event.h', prefix: '#include <sys/types.h>')
-      inotify = false
+      notify = 'kqueue'
     else
       error(
         'Couldn\'t determine notify implementation. Please set it with',
-        '-Dnotify-implementation=<inotify or kqueue> when creating the builddir.',
+        '-Dnotify-implementation=<inotify, kqueue or none> when creating the builddir.',
       )
     endif
   elif host_machine.system() == 'linux'
     # Using kqueue on Linux is very unlikely.
     if comp.check_header('sys/inotify.h')
-      inotify = true
+      notify = 'inotify'
     else
       error(
         'Couldn\'t determine notify implementation. Please report this to',
@@ -25,13 +25,13 @@ if get_option('notify-implementation') == 'auto'
     endif
   else
     if comp.check_header('sys/inotify.h')
-      inotify = true
+      notify = 'inotify'
     elif comp.check_header('sys/event.h', prefix: '#include <sys/types.h>')
-      inotify = false
+      notify = 'kqueue'
     else
       error(
         'Couldn\'t determine notify implementation. Please set it with',
-        '-Dnotify-implementation=<inotify or kqueue> when creating the builddir.',
+        '-Dnotify-implementation=<inotify, kqueue or none> when creating the builddir.',
       )
     endif
   endif
@@ -47,15 +47,25 @@ elif get_option('notify-implementation') == 'inotify'
 '''.substring(0, -1) # Strip the last \n
     )
   endif
-  inotify = true
+  notify = 'inotify'
 elif get_option('notify-implementation') == 'kqueue'
-  inotify = false
+  notify = 'kqueue'
+elif get_option('notify-implementation') == 'none'
+  warning(
+    'You have disabled the notify backend, the --wait-on flag will not work!',
+    'If you did this because of compilation issues or because of backend',
+    'autodetection issues, please report them at',
+    'https://github.com/enkore/j4-dmenu-desktop/issues/new.'
+  )
+  notify = 'none'
 endif
 
 flags = ['-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG']
 
-if not inotify
+if notify == 'kqueue'
   flags += '-DUSE_KQUEUE'
+elif notify == 'inotify'
+  flags += '-DUSE_INOTIFY'
 endif
 
 # Actual build definitions begin here.
@@ -97,9 +107,9 @@ src = files(
   'Utilities.cc',
 )
 
-if inotify
+if notify == 'inotify'
   src += files('NotifyInotify.cc')
-else
+elif notify == 'kqueue'
   src += files('NotifyKqueue.cc')
 endif
 

--- a/tests/TestNotify.cc
+++ b/tests/TestNotify.cc
@@ -33,7 +33,7 @@
 
 #ifdef USE_KQUEUE
 #include "NotifyKqueue.hh"
-#else
+#elif defined USE_INOTIFY
 #include "NotifyInotify.hh"
 #endif
 
@@ -47,7 +47,7 @@ TEST_CASE("Test detection of file creation and deletion of a subdirectory of "
     WARN("Tests on kqueue based systems can take about a minute. Please be "
          "patient.");
     NotifyKqueue notify(search_path);
-#else
+#elif defined USE_INOTIFY
     NotifyInotify notify(search_path);
 #endif
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -36,7 +36,6 @@ test_files = [
   'TestFileFinder.cc',
   'TestFormatters.cc',
   'TestLocaleSuffixes.cc',
-  'TestNotify.cc',
   'TestSearchPath.cc',
   'TestI3Exec.cc',
   'TestCMDLineTerm.cc',
@@ -44,6 +43,10 @@ test_files = [
   'TestCMDLineAssembler.cc',
   'MainTest.cc',
 ]
+
+if notify != 'none'
+  test_files += 'TestNotify.cc'
+endif
 
 subdir('generated')
 


### PR DESCRIPTION
Some systems have neither inotify nor kqueue, like GNU hurd. This patch allows compiling j4-dmenu-desktop on such systems, with the "--wait-on" feature disabled.

I tested [such a patch](https://sources.debian.org/src/j4-dmenu-desktop/3.2-2/debian/patches/Allow-to-compile-without-notify-support.patch) on Debian's hurd port.

It will also allow to add support for other notify implementations in the future.
