### PR TITLE
Improve support for "none" notify impl (like GNU Hurd)

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,9 @@ if get_option('notify-implementation') == 'auto'
         'https://github.com/enkore/j4-dmenu-desktop/issues/new',
       )
     endif
+  elif host_machine.system() == 'gnu'
+    # Support for GNU Hurd is not implemented.
+    notify = 'none'
   else
     if comp.check_header('sys/inotify.h')
       notify = 'inotify'

--- a/src/meson.build
+++ b/src/meson.build
@@ -62,6 +62,7 @@ elif get_option('notify-implementation') == 'none'
   )
   notify = 'none'
 endif
+summary('notify implementation', notify)
 
 flags = ['-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG']
 


### PR DESCRIPTION
As discussed in #202, disable support for notify with GNU hurd by default.

This is currently still a draft as I did not test it yet on Debian's build runners. I will mark it as ready once I do it.
